### PR TITLE
Loese Abhaengigkeit von HTTPS Ressourcen

### DIFF
--- a/opennet/packages/on-monitoring/files/usr/share/munin-plugins-available/olsr2
+++ b/opennet/packages/on-monitoring/files/usr/share/munin-plugins-available/olsr2
@@ -163,76 +163,8 @@ class socket(_socket.socket):
     def sendto(self, data, addr):
         return super().sendto(data, _resolve_addr(addr))
 
-# urllib ->
 
-
-def urlopen(url, data=None, method="GET"):
-    if data is not None and method == "GET":
-        method = "POST"
-    try:
-        proto, dummy, host, path = url.split("/", 3)
-    except ValueError:
-        proto, dummy, host = url.split("/", 2)
-        path = ""
-    if proto == "http:":
-        port = 80
-    elif proto == "https:":
-        import ussl
-
-        port = 443
-    else:
-        raise ValueError("Unsupported protocol: " + proto)
-
-    if ":" in host:
-        host, port = host.split(":", 1)
-        port = int(port)
-
-    ai = getaddrinfo(host, port, 0, SOCK_STREAM)
-    ai = ai[0]
-
-    s = socket(ai[0], ai[1], ai[2])
-    try:
-        s.connect(ai[-1])
-        if proto == "https:":
-            s = ussl.wrap_socket(s, server_hostname=host)
-
-        s.write(method)
-        s.write(b" /")
-        s.write(path)
-        s.write(b" HTTP/1.0\r\nHost: ")
-        s.write(host)
-        s.write(b"\r\n")
-
-        if data:
-            s.write(b"Content-Length: ")
-            s.write(str(len(data)))
-            s.write(b"\r\n")
-        s.write(b"\r\n")
-        if data:
-            s.write(data)
-
-        l = s.readline()
-        l = l.split(None, 2)
-        # print(l)
-        status = int(l[1])
-        while True:
-            l = s.readline()
-            if not l or l == b"\r\n":
-                break
-            # print(l)
-            if l.startswith(b"Transfer-Encoding:"):
-                if b"chunked" in l:
-                    raise ValueError("Unsupported " + l)
-            elif l.startswith(b"Location:"):
-                raise NotImplementedError("Redirects not yet supported")
-    except OSError:
-        s.close()
-        raise
-
-    return s
-# <- urllib
-
-plugin_version = "0.1"
+plugin_version = "0.2"
 
 NEIGHBOUR_GRAPH_CONFIG = """
 graph_title     {title}
@@ -352,19 +284,6 @@ def convert_bitrate_string(text):
     return 0
 
 
-def get_node_name(address, api_base="https://api.opennet-initiative.de/api/v1/accesspoint"):
-    try:
-        conn = urlopen("{}/{}".format(api_base, address))
-        data = conn.read()
-        conn.close()
-        position = data.find(b'"main_ip":')
-        if position >= 0:
-            return data[position + 10:].split(b'"')[1].decode()
-    except OSError:
-        pass
-    return address
-
-
 def get_olsr2_neighbours():
     route_count = count_routes_by_neighbour()
     result = []
@@ -377,7 +296,7 @@ def get_olsr2_neighbours():
         link["tx_bitrate"] = convert_bitrate_string(tokens[17])
         link["rx_bitrate"] = convert_bitrate_string(tokens[19])
         link["route_count"] = route_count.get(link_local_address, 0)
-        link["remote_name"] = get_node_name(link["remote_address"])
+        link["remote_name"] = link["remote_address"]
         link["remote_fieldname"] = get_clean_fieldname(link["remote_address"]).replace("_", "")
         result.append(link)
     result.sort(key=lambda link: link["remote_name"])


### PR DESCRIPTION
Mit dem aktuell von uns genutzten Micropython koennen wir nicht fehlerlos die API von Opennet per HTTPS ansprechen. Generell sollten wir Abhaengigkeiten von HTTPS/TLS verringern, weil wir auf den Servern Crypto fleissig aktualisieren, jedoch auf alten APs weniger oft die Firmware/Pakete aktualisieren. Daher wird es zwangslaeufig zu Inkompatibilitaeten kommen. Umso besser ist es, wenn wir weniger Abhaengigkeiten haben.
An dieser Stelle wurde die API nur benoetigt, um einen Anzeigenahmen zu erzeugen. Mit der Aenderung ist die plain IPv6 Adresse der Anzeigename. Das ist nicht schoen in der Ansicht aber der zukuenftigen Kompatibilitaet sehr dienlich.